### PR TITLE
Включить netsync для BaseLamp

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/fluff_lights.yml
@@ -44,7 +44,6 @@
     enabled: false
     radius: 3
     energy: 2
-    netsync: false
   - type: ToggleableLightVisuals
   - type: Appearance
   - type: Physics


### PR DESCRIPTION
Данное изменение позволит менять параметры цвета/яркости/etc для предметов с источником света (для маппинга)